### PR TITLE
Respect allowprerelease and allowunlisted

### DIFF
--- a/NuSave.Core/NuSave.cs
+++ b/NuSave.Core/NuSave.cs
@@ -200,8 +200,9 @@ namespace NuSave.Core
                     var found = Repository.FindPackage(
                         dependency.Id,
                         dependency.VersionSpec,
-                        true,
-                        true);
+                        _allowPreRelease,
+                        _allowUnlisted);
+
                     if (found == null)
                     {
                         Console.ForegroundColor = ConsoleColor.Red;


### PR DESCRIPTION
These two flags were not respected by the ResolveDependencies
method, except for the top package. It now looks at the command line flags set.